### PR TITLE
Improve database setup and order handling

### DIFF
--- a/app/crud/order.py
+++ b/app/crud/order.py
@@ -1,78 +1,95 @@
-from fastapi import HTTPException
-from sqlalchemy.orm import Session, joinedload
-from app.models.order import Order, OrderItem, OrderStatus
-from app.schemas.order import OrderCreate
-from app.models.product import Product
 import logging
 from datetime import datetime, timezone
 
+from fastapi import HTTPException
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.order import Order, OrderItem, OrderStatus
+from app.models.product import Product
+from app.schemas.order import OrderCreate
+
 logger = logging.getLogger(__name__)
 
- # Create a new order with product availability check and stock update
-def create_order(db: Session, order: OrderCreate) -> Order:   
-    try:
-        logger.info(f"Creating new order with data: {order.model_dump()}")
-        
-        # Initialize variables for order processing
-        total_price = 0
-        order_items = []
-        insufficient_stock = []
-        
-        # First pass: validate all products and check stock
-        for item in order.items:
-            product = db.query(Product).filter(Product.id == item.product_id).first()
-            if not product:
-                raise HTTPException(status_code=404, detail=f"Product with id {item.product_id} not found")
-            
-            if product.stock < item.quantity:
-                insufficient_stock.append({
-                    "product_id": product.id,
-                    "product_name": product.name,
-                    "requested": item.quantity,
-                    "available": product.stock
-                })
-        
-        # Return error if any product has insufficient stock
-        if insufficient_stock:
-            error_message = "Not enough stock for products:\n"
-            for item in insufficient_stock:
-                error_message += f"- {item['product_name']}: requested {item['requested']}, available {item['available']}\n"
-            raise HTTPException(status_code=400, detail=error_message)
-        
-        # Second pass: create order items and update stock
-        for item in order.items:
-            product = db.query(Product).filter(Product.id == item.product_id).first()
-            
-            # Update product stock and calculate total price
-            product.stock -= item.quantity
-            total_price += product.price * item.quantity
-            
-            # Create order item
-            db_item = OrderItem(
-                product_id=item.product_id,
-                quantity=item.quantity
-            )
-            order_items.append(db_item)
-            logger.info(f"Product {product.name} added to order. Stock: {product.stock}")
 
-        # Create and save the order
+# Create a new order with product availability check and stock update
+def create_order(db: Session, order: OrderCreate) -> Order:
+    try:
+        logger.info("Creating new order with data: %s", order.model_dump())
+
+        product_ids = [item.product_id for item in order.items]
+        if not product_ids:
+            raise HTTPException(status_code=400, detail="Order must contain at least one item")
+
+        # Aggregate quantities per product to avoid duplicate queries
+        requested_quantities: dict[int, int] = {}
+        for item in order.items:
+            requested_quantities[item.product_id] = requested_quantities.get(item.product_id, 0) + item.quantity
+
+        query = db.query(Product).filter(Product.id.in_(product_ids))
+        if db.bind and db.bind.dialect.name != "sqlite":
+            query = query.with_for_update()
+
+        products = {product.id: product for product in query.all()}
+
+        missing_products = set(product_ids) - set(products.keys())
+        if missing_products:
+            missing_id = next(iter(missing_products))
+            raise HTTPException(status_code=404, detail=f"Product with id {missing_id} not found")
+
+        insufficient_stock = []
+        for product_id, quantity in requested_quantities.items():
+            product = products[product_id]
+            if product.stock < quantity:
+                insufficient_stock.append(
+                    {
+                        "product_id": product.id,
+                        "product_name": product.name,
+                        "requested": quantity,
+                        "available": product.stock,
+                    }
+                )
+
+        if insufficient_stock:
+            error_lines = [
+                f"- {item['product_name']}: requested {item['requested']}, available {item['available']}"
+                for item in insufficient_stock
+            ]
+            raise HTTPException(
+                status_code=400,
+                detail="Not enough stock for products:\n" + "\n".join(error_lines),
+            )
+
+        total_price = 0.0
+        order_items: list[OrderItem] = []
+        for product_id, quantity in requested_quantities.items():
+            product = products[product_id]
+            product.stock -= quantity
+            total_price += product.price * quantity
+            order_items.append(
+                OrderItem(
+                    product_id=product_id,
+                    quantity=quantity,
+                )
+            )
+            logger.info("Product %s added to order. Stock: %s", product.name, product.stock)
+
         db_order = Order(
             status=OrderStatus.PENDING,
             price=total_price,
             created_at=datetime.now(timezone.utc),
-            items=order_items
+            items=order_items,
         )
-        
+
         db.add(db_order)
         db.commit()
         db.refresh(db_order)
-        logger.info(f"Order created successfully with ID: {db_order.id}")
+        logger.info("Order created successfully with ID: %s", db_order.id)
         return db_order
-    except HTTPException as e:
+    except HTTPException:
         db.rollback()
-        raise e
+        raise
     except Exception as e:
-        logger.error(f"Error creating order: {str(e)}")
+        logger.error("Error creating order: %s", str(e))
         db.rollback()
         raise HTTPException(status_code=500, detail=f"Error creating order: {str(e)}")
 

--- a/app/crud/product.py
+++ b/app/crud/product.py
@@ -1,8 +1,11 @@
+import logging
+
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
+
+from app.models.order import OrderItem
 from app.models.product import Product
 from app.schemas.product import ProductCreate, ProductUpdate
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +52,15 @@ def delete_product(db: Session, product_id: int):
     db_product = db.query(Product).filter(Product.id == product_id).first()
     if db_product is None:
         raise HTTPException(status_code=404, detail="Product not found")
-    
+
+    has_order_items = (
+        db.query(OrderItem).filter(OrderItem.product_id == product_id).count() > 0
+    )
+    if has_order_items:
+        raise HTTPException(
+            status_code=400,
+            detail="Product cannot be deleted while associated order items exist",
+        )
+
     db.delete(db_product)
     db.commit()

--- a/app/database.py
+++ b/app/database.py
@@ -1,17 +1,29 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
-import os
 
 # SQLite database URL
 SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./warehouse.db")
 
-# Create database engine with SQLite
-engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+
+def _engine_connect_args(database_url: str) -> dict:
+    if database_url.startswith("sqlite"):
+        return {"check_same_thread": False}
+    return {}
+
+
+# Create database engine with optional SQLite-specific args
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args=_engine_connect_args(SQLALCHEMY_DATABASE_URL),
+)
+
 # Create session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # Base class for declarative models
 Base = declarative_base()
+
 
 # Dependency to get DB session
 def get_db():

--- a/app/main.py
+++ b/app/main.py
@@ -8,11 +8,15 @@ from app.database import Base, engine
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Create all database tables
-Base.metadata.create_all(bind=engine)
-
 # Initialize FastAPI application
 app = FastAPI(title="Warehouse API")
+
+
+@app.on_event("startup")
+def on_startup():
+    """Ensure database schema is available when the app starts."""
+    Base.metadata.create_all(bind=engine)
+
 
 # Include routers
 app.include_router(product_router)

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -1,11 +1,14 @@
-from sqlalchemy import Column, Integer, Float, String, DateTime, ForeignKey, Enum
-from sqlalchemy.sql import func
-from sqlalchemy.orm import relationship
 from datetime import datetime
 import enum
+
+from sqlalchemy import Column, Integer, Float, String, DateTime, ForeignKey, Enum
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
 from app.database import Base
 
-class OrderStatus(enum.Enum):
+
+class OrderStatus(str, enum.Enum):
     PENDING = "pending"            # Order created but not yet confirmed (e.g., awaiting payment)
     CONFIRMED = "confirmed"        # Order confirmed (payment received or manually approved)
     IN_PROGRESS = "in progress"    # Order is being processed (e.g., packed at the warehouse)
@@ -39,7 +42,7 @@ class OrderItem(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     order_id = Column(Integer, ForeignKey("orders.id", ondelete="CASCADE"))
-    product_id = Column(Integer, ForeignKey("products.id"))
+    product_id = Column(Integer, ForeignKey("products.id", ondelete="RESTRICT"))
     quantity = Column(Integer, nullable=False)
     
     order = relationship("Order", back_populates="items")

--- a/app/routers/order.py
+++ b/app/routers/order.py
@@ -1,10 +1,19 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
+
+from app.crud.order import (
+    create_order,
+    delete_order,
+    get_order,
+    get_order_item,
+    get_orders,
+    update_order_status,
+)
 from app.database import get_db
-from app.schemas.order import OrderCreate, OrderRead, OrderStatus, OrderItemRead
 from app.models.order import OrderStatus
-from app.crud.order import create_order, get_orders, get_order, update_order_status, get_order_item, delete_order
-import logging
+from app.schemas.order import OrderCreate, OrderItemRead, OrderRead
 
 logger = logging.getLogger(__name__)
 

--- a/app/schemas/order.py
+++ b/app/schemas/order.py
@@ -1,21 +1,9 @@
-from pydantic import BaseModel, Field, ConfigDict, computed_field
-from typing import Optional, List
 from datetime import datetime
-from enum import Enum
-from app.models.product import Product
-from app.models.order import OrderItem
+from typing import Optional, List
 
-# Order status enum
-class OrderStatus(str, Enum):
-    PENDING = "pending"            # Order created but not yet confirmed (e.g., awaiting payment)
-    CONFIRMED = "confirmed"        # Order confirmed (payment received or manually approved)
-    IN_PROGRESS = "in progress"    # Order is being processed (e.g., packed at the warehouse)
-    SHIPPED = "shipped"            # Order has been shipped
-    DELIVERED = "delivered"        # Order has been delivered to the customer
-    COMPLETED = "completed"        # Order successfully completed (usually confirmed by customer)
-    CANCELLED = "cancelled"        # Order was cancelled by the customer or the store
-    REFUNDED = "refunded"          # Order was returned and the payment refunded
-    FAILED = "failed"              # Error occurred during order placement or payment
+from pydantic import BaseModel, Field, ConfigDict, computed_field
+
+from app.models.order import OrderStatus
 
 # Order item base model
 class OrderItemBase(BaseModel):
@@ -57,7 +45,7 @@ class OrderRead(BaseModel):
     id: int
     created_at: datetime
     status: OrderStatus
-    items: List[OrderItemRead] = []
+    items: List[OrderItemRead] = Field(default_factory=list)
     order_total: float = Field(alias="price")
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel, Field
 from typing import Optional
+
+from pydantic import BaseModel, Field, ConfigDict
+
 
 # Base product schema with common fields
 class ProductBase(BaseModel):
@@ -8,16 +10,17 @@ class ProductBase(BaseModel):
     price: float = Field(..., gt=0)
     stock: int = Field(..., ge=0)
 
+
 # Schema for creating a new product
 class ProductCreate(ProductBase):
     pass
 
-from pydantic import BaseModel, Field, ConfigDict
 
 # Schema for reading product data
 class ProductRead(ProductBase):
     id: int
     model_config = ConfigDict(from_attributes=True)
+
 
 # Schema for updating a product with optional fields
 class ProductUpdate(BaseModel):
@@ -25,6 +28,7 @@ class ProductUpdate(BaseModel):
     description: Optional[str] = Field(None, min_length=1, max_length=500)
     price: Optional[float] = Field(None, gt=0)
     stock: Optional[int] = Field(None, ge=0)
+
 
 # Schema for success message response
 class SuccessMessage(BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 sqlalchemy
 pydantic
 pytest
+httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,15 @@
 import os
+import sys
+from pathlib import Path
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from app.database import Base, get_db
 from app.main import app
@@ -43,3 +50,14 @@ def test_session(test_engine):
         session.query(Product).delete()
         session.commit()
         session.close()
+
+
+@pytest.fixture(scope="function")
+def client(test_session):
+    def override_get_db():
+        yield test_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,6 +1,5 @@
 import pytest
 from fastapi.testclient import TestClient
-from app.schemas.order import OrderStatus
 
 def test_create_order(client: TestClient):
     """Tests order creation"""


### PR DESCRIPTION
## Summary
- defer metadata creation to application startup and use database-specific engine options
- unify the order status enum across models/schemas and streamline order creation with aggregated stock checks
- harden product deletion rules, test fixtures, and dependencies for API tests

## Testing
- pytest -q *(fails: httpx unavailable in execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ff0003984832eba4e6c18542facd1)