### PR TITLE
Handle concurrent order creation safely

### DIFF
--- a/app/crud/order.py
+++ b/app/crud/order.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timezone
+from threading import Lock
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session, joinedload
@@ -10,86 +11,106 @@ from app.models.product import Product
 from app.schemas.order import OrderCreate
 
 logger = logging.getLogger(__name__)
+_order_creation_lock = Lock()
 
 
 # Create a new order with product availability check and stock update
 def create_order(db: Session, order: OrderCreate) -> Order:
-    try:
-        logger.info("Creating new order with data: %s", order.model_dump())
+    # SQLite in-memory databases share a single connection across threads.
+    # Use a mutex to serialize order creation and avoid connection-level
+    # conflicts during concurrent requests.
+    with _order_creation_lock:
+        try:
+            logger.info("Creating new order with data: %s", order.model_dump())
 
-        if not order.items:
-            raise HTTPException(
-                status_code=400, detail="Order must contain at least one item"
-            )
-
-        # Aggregate quantities to handle multiple items of the same product
-        requested_quantities: dict[int, int] = {}
-        for item in order.items:
-            requested_quantities[item.product_id] = (
-                requested_quantities.get(item.product_id, 0) + item.quantity
-            )
-
-        product_ids = list(requested_quantities.keys())
-        products = {
-            p.id: p for p in db.query(Product).filter(Product.id.in_(product_ids)).all()
-        }
-
-        # Verify that all products exist
-        if len(products) != len(product_ids):
-            missing_ids = set(product_ids) - set(products.keys())
-            raise HTTPException(
-                status_code=404, detail=f"Product with id {next(iter(missing_ids))} not found"
-            )
-
-        order_items: list[OrderItem] = []
-        for product_id, quantity in requested_quantities.items():
-            product = products[product_id]
-
-            # Atomic update to prevent race conditions
-            update_stmt = (
-                sqlalchemy_update(Product)
-                .where(Product.id == product_id)
-                .where(Product.stock >= quantity)
-                .values(stock=Product.stock - quantity)
-            )
-
-            result = db.execute(update_stmt)
-
-            if result.rowcount == 0:
-                # The update failed, meaning stock was insufficient
-                db.rollback()
+            if not order.items:
                 raise HTTPException(
-                    status_code=400,
-                    detail=f"Not enough stock for product: {product.name}",
+                    status_code=400, detail="Order must contain at least one item"
                 )
 
-            order_items.append(
-                OrderItem(
-                    product_id=product.id,
-                    quantity=quantity,
-                    price=product.price,
+            # Aggregate quantities to handle multiple items of the same product
+            requested_quantities: dict[int, int] = {}
+            for item in order.items:
+                requested_quantities[item.product_id] = (
+                    requested_quantities.get(item.product_id, 0) + item.quantity
                 )
+
+            product_ids = list(requested_quantities.keys())
+            products = {
+                p.id: p for p in db.query(Product).filter(Product.id.in_(product_ids)).all()
+            }
+
+            # Verify that all products exist
+            if len(products) != len(product_ids):
+                missing_ids = set(product_ids) - set(products.keys())
+                raise HTTPException(
+                    status_code=404, detail=f"Product with id {next(iter(missing_ids))} not found",
+                )
+
+            order_items: list[OrderItem] = []
+            for product_id, quantity in requested_quantities.items():
+                product = products[product_id]
+
+                # Atomic update to prevent race conditions
+                update_stmt = (
+                    sqlalchemy_update(Product)
+                    .where(Product.id == product_id)
+                    .where(Product.stock >= quantity)
+                    .values(stock=Product.stock - quantity)
+                )
+
+                result = db.execute(update_stmt)
+
+                if result.rowcount == 0:
+                    # The update failed, meaning stock was insufficient
+                    db.rollback()
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Not enough stock for product: {product.name}",
+                    )
+
+                order_items.append(
+                    OrderItem(
+                        product_id=product.id,
+                        quantity=quantity,
+                        price=product.price,
+                    )
+                )
+                logger.info("Product %s added to order. Stock updated.", product.name)
+
+            db_order = Order(
+                status=OrderStatus.PENDING,
+                created_at=datetime.now(timezone.utc),
+                items=order_items,
             )
-            logger.info("Product %s added to order. Stock updated.", product.name)
 
-        db_order = Order(
-            status=OrderStatus.PENDING,
-            created_at=datetime.now(timezone.utc),
-            items=order_items,
-        )
+            db.add(db_order)
 
-        db.add(db_order)
-        db.commit()
-        db.refresh(db_order)
-        logger.info("Order created successfully with ID: %s", db_order.id)
-        return db_order
-    except HTTPException:
-        db.rollback()
-        raise
-    except Exception as e:
-        logger.error("Error creating order: %s", str(e))
-        db.rollback()
-        raise HTTPException(status_code=500, detail=f"Error creating order: {str(e)}")
+            # Flush to assign primary keys before committing. This avoids
+            # refresh errors that can happen under concurrent access with
+            # SQLite's connection sharing.
+            db.flush()
+            order_id = db_order.id
+            db.commit()
+
+            db_order_result: Order | None = db_order
+            try:
+                db.refresh(db_order)
+            except Exception as e:
+                # The order is already committed; a refresh failure should not
+                # turn a successful creation into a 500 error.
+                logger.warning("Order committed but refresh failed: %s", str(e))
+                db_order_result = db.query(Order).filter(Order.id == order_id).first()
+
+            logger.info("Order created successfully with ID: %s", order_id)
+            return db_order_result
+        except HTTPException:
+            db.rollback()
+            raise
+        except Exception as e:
+            logger.error("Error creating order: %s", str(e))
+            db.rollback()
+            raise HTTPException(status_code=500, detail=f"Error creating order: {str(e)}")
 
 
 # Get paginated list of all orders


### PR DESCRIPTION
## Summary
- serialize order creation with a mutex to avoid connection conflicts during concurrent requests
- ensure order creation commits safely by flushing before commit and tolerating refresh issues by reloading the order
- preserve proper stock deductions and user-facing HTTP errors during oversell attempts

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692286f1f964832e98e59c9e474b8f53)